### PR TITLE
fix: fix resize feature for react 17

### DIFF
--- a/src/BackgroundCells.js
+++ b/src/BackgroundCells.js
@@ -72,8 +72,10 @@ class BackgroundCells extends React.Component {
 
   _selectable() {
     let node = findDOMNode(this)
-    let selector = (this._selector = new Selection(this.props.container, {
-      longPressThreshold: this.props.longPressThreshold,
+    const { container, longPressThreshold, getRootNode } = this.props
+    let selector = (this._selector = new Selection(container, {
+      longPressThreshold,
+      getRootNode,
     }))
 
     let selectorClicksHandler = (point, actionType) => {
@@ -171,6 +173,7 @@ BackgroundCells.propTypes = {
 
   getters: PropTypes.object.isRequired,
   components: PropTypes.object.isRequired,
+  getRootNode: PropTypes.func.isRequired,
 
   container: PropTypes.func,
   dayPropGetter: PropTypes.func,

--- a/src/Calendar.js
+++ b/src/Calendar.js
@@ -274,6 +274,16 @@ class Calendar extends React.Component {
     getNow: PropTypes.func,
 
     /**
+     * Get react root node
+     *
+     * Since React 17 the document object can't be used anymore as a target for
+     * event handler.
+     *
+     * @type {func}
+     */
+    getRootNode: PropTypes.func.isRequired,
+
+    /**
      * Callback fired when the `date` value changes.
      *
      * @controllable date

--- a/src/DateContentRow.js
+++ b/src/DateContentRow.js
@@ -111,6 +111,7 @@ class DateContentRow extends React.Component {
       accessors,
       getters,
       components,
+      getRootNode,
 
       getNow,
       renderHeader,
@@ -147,8 +148,9 @@ class DateContentRow extends React.Component {
       onDoubleClick,
       onKeyPress,
       resourceId,
-      slotMetrics: metrics,
       resizable,
+      getRootNode,
+      slotMetrics: metrics,
     }
 
     return (
@@ -168,6 +170,7 @@ class DateContentRow extends React.Component {
           components={components}
           longPressThreshold={longPressThreshold}
           resourceId={resourceId}
+          getRootNode={getRootNode}
         />
 
         <div
@@ -235,6 +238,7 @@ DateContentRow.propTypes = {
   components: PropTypes.object.isRequired,
   getters: PropTypes.object.isRequired,
   localizer: PropTypes.object.isRequired,
+  getRootNode: PropTypes.func.isRequired,
 
   minRows: PropTypes.number.isRequired,
   maxRows: PropTypes.number.isRequired,

--- a/src/DayColumn.js
+++ b/src/DayColumn.js
@@ -113,6 +113,7 @@ class DayColumn extends React.Component {
       resource,
       accessors,
       localizer,
+      getRootNode,
       getters: { dayProp, ...getters },
       components: { eventContainerWrapper: EventContainer, ...components },
     } = this.props
@@ -156,6 +157,7 @@ class DayColumn extends React.Component {
           getters={getters}
           components={components}
           slotMetrics={slotMetrics}
+          getRootNode={getRootNode}
         >
           <div className={clsx('rbc-events-container', rtl && 'rtl')}>
             {this.renderEvents({
@@ -249,9 +251,10 @@ class DayColumn extends React.Component {
 
   _selectable = () => {
     let node = findDOMNode(this)
-    const { longPressThreshold, localizer } = this.props
+    const { longPressThreshold, localizer, getRootNode } = this.props
     let selector = (this._selector = new Selection(() => findDOMNode(this), {
-      longPressThreshold: longPressThreshold,
+      longPressThreshold,
+      getRootNode,
     }))
 
     let maybeSelect = box => {
@@ -405,6 +408,7 @@ DayColumn.propTypes = {
   components: PropTypes.object.isRequired,
   getters: PropTypes.object.isRequired,
   localizer: PropTypes.object.isRequired,
+  getRootNode: PropTypes.func.isRequired,
 
   showMultiDayTimes: PropTypes.bool,
   culture: PropTypes.string,

--- a/src/Month.js
+++ b/src/Month.js
@@ -107,6 +107,7 @@ class MonthView extends React.Component {
       accessors,
       getters,
       showAllEvents,
+      getRootNode,
     } = this.props
 
     const { needLimitMeasure, rowLimit } = this.state
@@ -150,6 +151,7 @@ class MonthView extends React.Component {
         rtl={this.props.rtl}
         resizable={this.props.resizable}
         showAllEvents={showAllEvents}
+        getRootNode={getRootNode}
       />
     )
   }
@@ -354,6 +356,7 @@ MonthView.propTypes = {
   components: PropTypes.object.isRequired,
   getters: PropTypes.object.isRequired,
   localizer: PropTypes.object.isRequired,
+  getRootNode: PropTypes.func.isRequired,
 
   selected: PropTypes.object,
   selectable: PropTypes.oneOf([true, false, 'ignoreEvents']),

--- a/src/Selection.js
+++ b/src/Selection.js
@@ -2,8 +2,10 @@ import contains from 'dom-helpers/contains'
 import closest from 'dom-helpers/closest'
 import listen from 'dom-helpers/listen'
 
-function addEventListener(type, handler, target = document) {
-  return listen(target, type, handler, { passive: false })
+function getEventListenerFunc(getRootNode) {
+  return function addEventListener(type, handler, target = getRootNode()) {
+    return listen(target, type, handler, { passive: false })
+  }
 }
 
 function isOverContainer(container, x, y) {
@@ -38,11 +40,15 @@ const clickTolerance = 5
 const clickInterval = 250
 
 class Selection {
-  constructor(node, { global = false, longPressThreshold = 250 } = {}) {
+  constructor(
+    node,
+    { getRootNode, global = false, longPressThreshold = 250 } = {}
+  ) {
     this.isDetached = false
     this.container = node
     this.globalMouse = !node || global
     this.longPressThreshold = longPressThreshold
+    this.addEventListener = getEventListenerFunc(getRootNode)
 
     this._listeners = Object.create(null)
 
@@ -57,18 +63,24 @@ class Selection {
 
     // Fixes an iOS 10 bug where scrolling could not be prevented on the window.
     // https://github.com/metafizzy/flickity/issues/457#issuecomment-254501356
-    this._removeTouchMoveWindowListener = addEventListener(
+    this._removeTouchMoveWindowListener = this.addEventListener(
       'touchmove',
       () => {},
       window
     )
-    this._removeKeyDownListener = addEventListener('keydown', this._keyListener)
-    this._removeKeyUpListener = addEventListener('keyup', this._keyListener)
-    this._removeDropFromOutsideListener = addEventListener(
+    this._removeKeyDownListener = this.addEventListener(
+      'keydown',
+      this._keyListener
+    )
+    this._removeKeyUpListener = this.addEventListener(
+      'keyup',
+      this._keyListener
+    )
+    this._removeDropFromOutsideListener = this.addEventListener(
       'drop',
       this._dropFromOutsideListener
     )
-    this._removeDragOverFromOutsideListener = addEventListener(
+    this._removeDragOverFromOutsideListener = this.addEventListener(
       'dragover',
       this._dragOverFromOutsideListener
     )
@@ -108,7 +120,8 @@ class Selection {
     this._removeKeyUpListener && this._removeKeyUpListener()
     this._removeKeyDownListener && this._removeKeyDownListener()
     this._removeDropFromOutsideListener && this._removeDropFromOutsideListener()
-    this._removeDragOverFromOutsideListener && this._removeDragOverFromOutsideListener()
+    this._removeDragOverFromOutsideListener &&
+      this._removeDragOverFromOutsideListener()
   }
 
   isSelected(node) {
@@ -139,10 +152,14 @@ class Selection {
         cleanup()
         handler(initialEvent)
       }, this.longPressThreshold)
-      removeTouchMoveListener = addEventListener('touchmove', () => cleanup())
-      removeTouchEndListener = addEventListener('touchend', () => cleanup())
+      removeTouchMoveListener = this.addEventListener('touchmove', () =>
+        cleanup()
+      )
+      removeTouchEndListener = this.addEventListener('touchend', () =>
+        cleanup()
+      )
     }
-    const removeTouchStartListener = addEventListener(
+    const removeTouchStartListener = this.addEventListener(
       'touchstart',
       handleTouchStart
     )
@@ -175,15 +192,15 @@ class Selection {
   // Listen for mousedown and touchstart events. When one is received, disable the other and setup
   // future event handling based on the type of event.
   _addInitialEventListener() {
-    const removeMouseDownListener = addEventListener('mousedown', e => {
+    const removeMouseDownListener = this.addEventListener('mousedown', e => {
       this._removeInitialEventListener()
       this._handleInitialEvent(e)
-      this._removeInitialEventListener = addEventListener(
+      this._removeInitialEventListener = this.addEventListener(
         'mousedown',
         this._handleInitialEvent
       )
     })
-    const removeTouchStartListener = addEventListener('touchstart', e => {
+    const removeTouchStartListener = this.addEventListener('touchstart', e => {
       this._removeInitialEventListener()
       this._removeInitialEventListener = this._addLongPressListener(
         this._handleInitialEvent,
@@ -274,26 +291,26 @@ class Selection {
 
     switch (e.type) {
       case 'mousedown':
-        this._removeEndListener = addEventListener(
+        this._removeEndListener = this.addEventListener(
           'mouseup',
           this._handleTerminatingEvent
         )
-        this._onEscListener = addEventListener(
+        this._onEscListener = this.addEventListener(
           'keydown',
           this._handleTerminatingEvent
         )
-        this._removeMoveListener = addEventListener(
+        this._removeMoveListener = this.addEventListener(
           'mousemove',
           this._handleMoveEvent
         )
         break
       case 'touchstart':
         this._handleMoveEvent(e)
-        this._removeEndListener = addEventListener(
+        this._removeEndListener = this.addEventListener(
           'touchend',
           this._handleTerminatingEvent
         )
-        this._removeMoveListener = addEventListener(
+        this._removeMoveListener = this.addEventListener(
           'touchmove',
           this._handleMoveEvent
         )

--- a/src/TimeGrid.js
+++ b/src/TimeGrid.js
@@ -184,6 +184,7 @@ export default class TimeGrid extends Component {
       showMultiDayTimes,
       longPressThreshold,
       resizable,
+      getRootNode,
     } = this.props
 
     width = width || this.state.gutterWidth
@@ -252,6 +253,7 @@ export default class TimeGrid extends Component {
           onDrillDown={this.props.onDrillDown}
           getDrilldownView={this.props.getDrilldownView}
           resizable={resizable}
+          getRootNode={getRootNode}
         />
         <div
           ref={this.contentRef}
@@ -362,6 +364,7 @@ TimeGrid.propTypes = {
   components: PropTypes.object.isRequired,
   getters: PropTypes.object.isRequired,
   localizer: PropTypes.object.isRequired,
+  getRootNode: PropTypes.func.isRequired,
 
   selected: PropTypes.object,
   selectable: PropTypes.oneOf([true, false, 'ignoreEvents']),

--- a/src/TimeGridHeader.js
+++ b/src/TimeGridHeader.js
@@ -71,6 +71,7 @@ class TimeGridHeader extends React.Component {
       accessors,
       components,
       resizable,
+      getRootNode,
     } = this.props
 
     const resourceId = accessors.resourceId(resource)
@@ -100,6 +101,7 @@ class TimeGridHeader extends React.Component {
         onSelectSlot={this.props.onSelectSlot}
         longPressThreshold={this.props.longPressThreshold}
         resizable={resizable}
+        getRootNode={getRootNode}
       />
     )
   }
@@ -119,11 +121,12 @@ class TimeGridHeader extends React.Component {
       scrollRef,
       localizer,
       isOverflowing,
+      resizable,
+      getRootNode,
       components: {
         timeGutterHeader: TimeGutterHeader,
         resourceHeader: ResourceHeaderComponent = ResourceHeader,
       },
-      resizable,
     } = this.props
 
     let style = {}
@@ -187,6 +190,7 @@ class TimeGridHeader extends React.Component {
               onSelectSlot={this.props.onSelectSlot}
               longPressThreshold={this.props.longPressThreshold}
               resizable={resizable}
+              getRootNode={getRootNode}
             />
           </div>
         ))}
@@ -210,6 +214,7 @@ TimeGridHeader.propTypes = {
   accessors: PropTypes.object.isRequired,
   components: PropTypes.object.isRequired,
   getters: PropTypes.object.isRequired,
+  getRootNode: PropTypes.func.isRequired,
 
   selected: PropTypes.object,
   selectable: PropTypes.oneOf([true, false, 'ignoreEvents']),

--- a/src/addons/dragAndDrop/EventContainerWrapper.js
+++ b/src/addons/dragAndDrop/EventContainerWrapper.js
@@ -17,6 +17,7 @@ class EventContainerWrapper extends React.Component {
     getters: PropTypes.object.isRequired,
     localizer: PropTypes.object.isRequired,
     slotMetrics: PropTypes.object.isRequired,
+    getRootNode: PropTypes.func.isRequired,
     resource: PropTypes.any,
   }
 
@@ -108,8 +109,10 @@ class EventContainerWrapper extends React.Component {
     let wrapper = this.ref.current
     let node = wrapper.children[0]
     let isBeingDragged = false
-    let selector = (this._selector = new Selection(() =>
-      wrapper.closest('.rbc-time-view')
+    const { getRootNode } = this.props
+    let selector = (this._selector = new Selection(
+      () => wrapper.closest('.rbc-time-view'),
+      { getRootNode }
     ))
 
     selector.on('beforeSelect', point => {

--- a/src/addons/dragAndDrop/WeekWrapper.js
+++ b/src/addons/dragAndDrop/WeekWrapper.js
@@ -14,6 +14,7 @@ class WeekWrapper extends React.Component {
     accessors: PropTypes.object.isRequired,
     getters: PropTypes.object.isRequired,
     components: PropTypes.object.isRequired,
+    getRootNode: PropTypes.func.isRequired,
     resourceId: PropTypes.any,
     rtl: PropTypes.bool,
     localizer: PropTypes.any,
@@ -150,7 +151,10 @@ class WeekWrapper extends React.Component {
     let node = this.ref.current.closest('.rbc-month-row, .rbc-allday-cell')
     let container = node.closest('.rbc-month-view, .rbc-time-view')
 
-    let selector = (this._selector = new Selection(() => container))
+    const { getRootNode } = this.props
+    let selector = (this._selector = new Selection(() => container, {
+      getRootNode,
+    }))
 
     selector.on('beforeSelect', point => {
       const { isAllDay } = this.props


### PR DESCRIPTION
Since React 17 the document object can't be used anymore as a target for the event handler. React root node must be used instead.

https://reactjs.org/blog/2020/08/10/react-v17-rc.html#changes-to-event-delegation